### PR TITLE
Add docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+############################################################
+# Dockerfile to build Python WSGI Application Containers
+# Based on Ubuntu
+############################################################
+
+# Set the base image to Ubuntu
+FROM ubuntu
+
+# File Author / Maintainer
+MAINTAINER Eric Hutton
+
+# Add the application resources URL
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ $(. /etc/lsb-release && printf '%s' $DISTRIB_CODENAME) main universe" >> /etc/apt/sources.list
+
+# Update the sources list
+RUN apt-get update
+
+# Install basic applications
+RUN apt-get install -y tar git curl vim dialog net-tools build-essential lsb-release
+
+# Install Python and Basic Python Tools
+RUN curl https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > miniconda.sh
+RUN /bin/bash ./miniconda.sh -b -f -p /usr/local/python
+RUN export PATH=/usr/local/python/bin:$PATH
+RUN /usr/local/python/bin/conda config --add channels conda-forge
+RUN /usr/local/python/bin/conda config --add channels landlab
+
+# Copy the application folder inside the container
+ADD . /landlab-rest
+
+# Get pip to download and install requirements:
+RUN /usr/local/python/bin/conda install --yes --file=/landlab-rest/requirements.txt
+
+# Expose ports
+EXPOSE 80
+
+# Set the default directory where CMD will execute
+WORKDIR /landlab-rest
+
+# Set the default command to execute
+# when creating a new container
+# i.e. using CherryPy to serve the application
+CMD /usr/local/python/bin/python server.py

--- a/README.rst
+++ b/README.rst
@@ -43,3 +43,27 @@ You can pass parameters like,
 .. code::
 
     $ curl 'https://0.0.0.0:8080/graphs/raster?shape=4,5&spacing=2.,1.'
+
+
+------
+Docker
+------
+
+To build a new docker image that will be a landlab-rest server,
+
+.. code::
+
+    docker build . -t landlab-rest
+
+
+After building, run the server,
+
+.. code::
+
+    docker run -it -p 80:80 landlab-rest
+
+Once running, you can then send requests to the server. For example,
+
+.. code::
+
+    $ curl https://0.0.0.0/graphs/raster

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 cherrypy
 landlab
+xarray


### PR DESCRIPTION
This pull requests adds a Dockerfile to create a docker image that will run a landlab-rest server. Brief documentation on how build and run the image is in `README.rst`.