### PR TITLE
Gt add grid outputs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,8 @@ Start the server,
 
     $ python ./server.py
 
-(note: you might need to use: sudo python ./server.py)
+(note: depending on the port, you might need to use:
+`sudo python ./server.py`)
 
 Look at the line containing `Serving on` to see what host and port the
 server is running on. Alternatively, you can use the `--host` and `--port`
@@ -32,19 +33,19 @@ to get a `RasterModelGrid`,
 
 .. code::
 
-    $ curl https://0.0.0.0:8080/graphs/raster
+    $ curl http://0.0.0.0:8080/graphs/raster
 
 For a list of supported graphs
 
 .. code::
 
-    $ curl https://0.0.0.0:8080/graphs/
+    $ curl http://0.0.0.0:8080/graphs/
 
 You can pass parameters like,
 
 .. code::
 
-    $ curl 'https://0.0.0.0:8080/graphs/raster?shape=4,5&spacing=2.,1.'
+    $ curl 'http://0.0.0.0:8080/graphs/raster?shape=4,5&spacing=2.,1.'
 
 
 ------
@@ -68,4 +69,4 @@ Once running, you can then send requests to the server. For example,
 
 .. code::
 
-    $ curl https://0.0.0.0/graphs/raster
+    $ curl http://0.0.0.0/graphs/raster

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ Start the server,
 
     $ python ./server.py
 
+(note: you might need to use: sudo python ./server.py)
+
 Look at the line containing `Serving on` to see what host and port the
 server is running on. Alternatively, you can use the `--host` and `--port`
 options to specify a specific host and port (`--help` for help).

--- a/landlab_rest/api/graphs.py
+++ b/landlab_rest/api/graphs.py
@@ -6,6 +6,7 @@ import xarray as xr
 import numpy as np
 
 import landlab
+from landlab.graph import DualUniformRectilinearGraph
 
 
 graphs_page = Blueprint('graphs', __name__)
@@ -86,8 +87,7 @@ def raster():
     spacing = [float(n) for n in args['spacing'].split(',')]
 
     grid = landlab.RasterModelGrid(shape, spacing=spacing)
-    graph = landlab.graph.DualUniformRectilinearGraph(shape,
-                                                      spacing=spacing)
+    graph = DualUniformRectilinearGraph(shape, spacing=spacing)
     return as_resource(to_resource(
         grid, graph,
         href='/graph/raster?{params}'.format(params=urllib.urlencode(args))))

--- a/landlab_rest/api/graphs.py
+++ b/landlab_rest/api/graphs.py
@@ -114,14 +114,17 @@ def hex():
 
 @graphs_page.route('/radial')
 def radial():
-    #args = dict(shape=request.args.get('shape', '4,4'))
-    args = dict(shape=request.args.get('shape', '1,1'))
+    args = dict(shape=request.args.get('shape', '4,6'),
+                spacing=request.args.get('spacing', '1.'))
+    # args = dict(shape=request.args.get('shape', '1,1'))
 
     shape = [int(n) for n in args['shape'].split(',')]
-    #n_shells, dr = shape[0], 2. * np.pi / shape[1]
-    n_shells, dr = shape[0], shape[1]
+    spacing = float(args['spacing'])
+    # n_shells, dr = shape[0], 2. * np.pi / shape[1]
+    #n_shells, dr = shape[0], shape[1]
 
-    graph = DualRadialGraph(shape=(shape[0], 6), spacing=dr)
+    graph = DualRadialGraph(shape=shape, spacing=spacing)
+    # graph = DualRadialGraph(shape=(shape[0], 6), spacing=dr)
 
     return as_resource(to_resource(
         graph,

--- a/landlab_rest/api/graphs.py
+++ b/landlab_rest/api/graphs.py
@@ -31,27 +31,37 @@ def jsonify_collection(items):
                     mimetype='application/x-collection+json; charset=utf-8')
 
 
-def to_resource(grid, href=None):
+def to_resource(grid, graph, href=None):
     return {
         '_type': 'graph',
         'href': href,
-        'graph': grid_as_dict(grid),
+        'graph': grid_as_dict(grid, graph),
     }
 
 
-def grid_as_dict(grid):
+def grid_as_dict(grid, graph):
     nodes_at_link = np.vstack((grid.node_at_link_tail,
                                grid.node_at_link_head)).T
+    corners_at_face = np.vstack((graph.corner_at_face_tail,
+                                 graph.corner_at_face_head)).T
 
     dataset = xr.Dataset({
         'y_of_node': xr.DataArray(grid.y_of_node, dims=('node', )),
         'x_of_node': xr.DataArray(grid.x_of_node, dims=('node', )),
+        'y_of_corner': xr.DataArray(graph.y_of_corner, dims=('corner', )),
+        'x_of_corner': xr.DataArray(graph.x_of_corner, dims=('corner', )),
         'y_of_link': xr.DataArray(grid.y_of_link, dims=('link', )),
         'x_of_link': xr.DataArray(grid.x_of_link, dims=('link', )),
+        'y_of_face': xr.DataArray(grid.y_of_face, dims=('face', )),
+        'x_of_face': xr.DataArray(grid.x_of_face, dims=('face', )),
         'nodes_at_link': xr.DataArray(nodes_at_link,
                                       dims=('link', 'nodes_per_link', )),
+        'corners_at_face': xr.DataArray(corners_at_face,
+                                      dims=('face', 'corners_per_face', )),
         'nodes_at_patch': xr.DataArray(grid.nodes_at_patch,
                                        dims=('patch', 'nodes_per_patch', )),
+        'corners_at_cell': xr.DataArray(graph.corners_at_cell,
+                                        dims=('cell', 'corners_per_cell', )),
     })
 
     return dataset.to_dict()
@@ -76,8 +86,10 @@ def raster():
     spacing = [float(n) for n in args['spacing'].split(',')]
 
     grid = landlab.RasterModelGrid(shape, spacing=spacing)
+    graph = landlab.graph.DualUniformRectilinearGraph(shape,
+                                                      spacing=spacing)
     return as_resource(to_resource(
-        grid,
+        grid, graph,
         href='/graph/raster?{params}'.format(params=urllib.urlencode(args))))
 
 

--- a/landlab_rest/api/graphs.py
+++ b/landlab_rest/api/graphs.py
@@ -46,6 +46,8 @@ def grid_as_dict(grid):
     dataset = xr.Dataset({
         'y_of_node': xr.DataArray(grid.y_of_node, dims=('node', )),
         'x_of_node': xr.DataArray(grid.x_of_node, dims=('node', )),
+        'y_of_link': xr.DataArray(grid.y_of_link, dims=('link', )),
+        'x_of_link': xr.DataArray(grid.x_of_link, dims=('link', )),
         'nodes_at_link': xr.DataArray(nodes_at_link,
                                       dims=('link', 'nodes_per_link', )),
         'nodes_at_patch': xr.DataArray(grid.nodes_at_patch,

--- a/landlab_rest/api/graphs.py
+++ b/landlab_rest/api/graphs.py
@@ -6,7 +6,8 @@ import xarray as xr
 import numpy as np
 
 import landlab
-from landlab.graph import DualUniformRectilinearGraph
+from landlab.graph import (DualUniformRectilinearGraph, DualHexGraph,
+                           DualRadialGraph)
 
 
 graphs_page = Blueprint('graphs', __name__)
@@ -88,6 +89,7 @@ def raster():
 
     grid = landlab.RasterModelGrid(shape, spacing=spacing)
     graph = DualUniformRectilinearGraph(shape, spacing=spacing)
+
     return as_resource(to_resource(
         grid, graph,
         href='/graph/raster?{params}'.format(params=urllib.urlencode(args))))
@@ -102,21 +104,25 @@ def hex():
     spacing = float(args['spacing'])
 
     grid = landlab.HexModelGrid(*shape, dx=spacing)
+    graph = DualHexGraph(shape, spacing=spacing, node_layout='hex')
 
     return as_resource(to_resource(
-        grid,
+        grid, graph,
         href='/graph/hex?{params}'.format(params=urllib.urlencode(args))))
 
 
 @graphs_page.route('/radial')
 def radial():
-    args = dict(shape=request.args.get('shape', '4,4'))
+    #args = dict(shape=request.args.get('shape', '4,4'))
+    args = dict(shape=request.args.get('shape', '1,1'))
 
     shape = [int(n) for n in args['shape'].split(',')]
-    n_shells, dr = shape[0], 2. * np.pi / shape[1]
+    #n_shells, dr = shape[0], 2. * np.pi / shape[1]
+    n_shells, dr = shape[0], shape[1]
 
     grid = landlab.RadialModelGrid(n_shells, dr)
+    graph = DualRadialGraph(shape=(shape[0], 6), spacing=dr)
 
     return as_resource(to_resource(
-        grid,
+        grid, graph,
         href='/graph/radial?{params}'.format(params=urllib.urlencode(args))))

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--port', type=int, default=80,
+    parser.add_argument('-p', '--port', type=int, default=8080,
                         help='port to run on')
     parser.add_argument('--host', type=str, default='0.0.0.0',
                         help='host IP address')


### PR DESCRIPTION
With this PR, the API now creates graph as well as grid objects, and the resulting JSON file gets info on patches, corners, and faces as well as nodes, links, and cells.

One remaining issue: radial grids. I changed the default to a single shell, with 6 nodes in the first ring (which had previously been the built-in behavior of RadialModelGrid). Requesting more than one ring produces an array mis-match error that I don't understand. @mcflugen could you take a look? I left the old code commented out for comparison.