### PR TITLE
Update for Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update
 RUN apt-get install -y tar git curl vim dialog net-tools build-essential lsb-release
 
 # Install Python and Basic Python Tools
-RUN curl https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > miniconda.sh
+RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > miniconda.sh
 RUN /bin/bash ./miniconda.sh -b -f -p /usr/local/python
 RUN export PATH=/usr/local/python/bin:$PATH
 RUN /usr/local/python/bin/conda config --add channels conda-forge

--- a/landlab_rest/api/graphs.py
+++ b/landlab_rest/api/graphs.py
@@ -76,7 +76,7 @@ def raster():
     grid = landlab.RasterModelGrid(shape, spacing=spacing)
     return as_resource(to_resource(
         grid,
-        href='/graph/raster?{params}'.format(params=urllib.urlencode(args))))
+        href='/graph/raster?{params}'.format(params=urllib.parse.urlencode(args))))
 
 
 @graphs_page.route('/hex')
@@ -91,7 +91,7 @@ def hex():
 
     return as_resource(to_resource(
         grid,
-        href='/graph/hex?{params}'.format(params=urllib.urlencode(args))))
+        href='/graph/hex?{params}'.format(params=urllib.parse.urlencode(args))))
 
 
 @graphs_page.route('/radial')
@@ -105,4 +105,4 @@ def radial():
 
     return as_resource(to_resource(
         grid,
-        href='/graph/radial?{params}'.format(params=urllib.urlencode(args))))
+        href='/graph/radial?{params}'.format(params=urllib.parse.urlencode(args))))


### PR DESCRIPTION
Update to work with python 3. The only change was to use *urlencode* from its new location. This breaks backward compatibility with Python 2.

BREAKING CHANGE: *landlab_rest* is now just python 3