### PR TITLE
Add startup script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,17 +9,18 @@ A RESTful interface to landlab graphs.
 Quickstart
 ----------
 
-Use `conda` to install the necessary requirements,
+Use `conda` to install the necessary requirements and `landlab_rest`,
 
 .. code::
 
-    $ conda install --file=requirements.txt -c conda-forge -c landlab
+    $ conda install --file=requirements.txt -c conda-forge
+    $ pip install .
 
 Start the server,
 
 .. code::
 
-    $ python ./server.py
+    $ start-landlab-sketchbook
 
 Look at the line containing `Serving on` to see what host and port the
 server is running on. Alternatively, you can use the `--host` and `--port`

--- a/landlab_rest/start.py
+++ b/landlab_rest/start.py
@@ -1,21 +1,16 @@
+import cherrypy
+
 from landlab_rest import create_app
 
-
 app = create_app()
-
-
-# Import CherryPy
-import cherrypy
 
 
 def main():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--port', type=int, default=80,
-                        help='port to run on')
-    parser.add_argument('--host', type=str, default='0.0.0.0',
-                        help='host IP address')
+    parser.add_argument("-p", "--port", type=int, default=80, help="port to run on")
+    parser.add_argument("--host", type=str, default="0.0.0.0", help="host IP address")
 
     args = parser.parse_args()
 
@@ -46,7 +41,3 @@ def main():
 
     cherrypy.engine.start()
     cherrypy.engine.block()
-
-
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,5 @@ setup(
     install_requires=["flask", "cherrypy", "landlab", "xarray"],
     packages=find_packages(),
     cmdclass=versioneer.get_cmdclass(),
+    entry_points={"console_scripts": ["start-landlab-sketchbook=landlab_rest.run:main"]},
 )


### PR DESCRIPTION
Previously, the *landlab_rest* service could be started with the `server.py` script. This pull request just moves that script into the package and installs it so that a user doesn't have to run it from source.