### PR TITLE
Update for landlab v2 grids

### DIFF
--- a/landlab_rest/api/graphs.py
+++ b/landlab_rest/api/graphs.py
@@ -36,6 +36,14 @@ def to_resource(grid, href=None, repr_=None):
 
 
 def grid_as_dict(grid):
+    grid.ds.update(
+        {
+            "x_of_corner": (("corner",), grid.x_of_corner),
+            "y_of_corner": (("corner",), grid.y_of_corner),
+            "faces_at_cell": (("cell", "max_cell_faces"), grid.faces_at_cell),
+            "corners_at_face": (("face", "Two"), grid.corners_at_face),
+        }
+    )
     return grid.ds.to_dict()
 
 
@@ -91,9 +99,10 @@ def hex():
     grid = landlab.graph.DualHexGraph(
         shape,
         spacing=spacing,
-        origin=origin,
+        xy_of_lower_left=origin,
         orientation=args["orientation"],
         node_layout=args["node_layout"],
+        sort=True,
     )
 
     return as_resource(
@@ -102,7 +111,7 @@ def hex():
             href=urllib.parse.urlunsplit(
                 ("", "", "/graphs/hex", urllib.parse.urlencode(args), "")
             ),
-            repr_="DualHexGraph({shape}, spacing={spacing}, origin={origin}, orientation={orientation}, node_layout={node_layout})".format(
+            repr_="DualHexGraph({shape}, spacing={spacing}, xy_of_lower_left={origin}, orientation={orientation}, node_layout={node_layout})".format(
                 shape=repr(shape),
                 spacing=repr(spacing),
                 origin=repr(origin),
@@ -125,7 +134,9 @@ def radial():
     spacing = float(args["spacing"])
     origin = tuple(float(n) for n in args["origin"].split(","))
 
-    grid = landlab.graph.DualRadialGraph(shape, spacing=spacing, origin=origin)
+    grid = landlab.graph.DualRadialGraph(
+        shape, spacing=spacing, xy_of_center=origin, sort=True
+    )
 
     return as_resource(
         to_resource(
@@ -133,7 +144,7 @@ def radial():
             href=urllib.parse.urlunsplit(
                 ("", "", "/graphs/radial", urllib.parse.urlencode(args), "")
             ),
-            repr_="DualRadialGraph({shape}, spacing={spacing}, origin={origin})".format(
+            repr_="DualRadialGraph({shape}, spacing={spacing}, xy_of_center={origin})".format(
                 shape=repr(shape), spacing=repr(spacing), origin=repr(origin)
             ),
         )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    install_requires=["flask", "cherrypy", "click", "landlab", "xarray"],
+    install_requires=["flask", "cherrypy", "click", "landlab>=2", "xarray"],
     packages=find_packages(),
     cmdclass=versioneer.get_cmdclass(),
     entry_points={"console_scripts": ["start-sketchbook=landlab_rest.cli:main"]},


### PR DESCRIPTION
This pull request updates *landlab-rest* to work with *landlab* v2 graphs. This allows *landlab-rest* to use newer versions of *landlab* and also still work with the *grid-sketchbook*.

Adds the dual graph properties to the returned grids,
* *x_of_corner*, *y_of_corner*
* *faces_at_cell*
* *corners_at_face*

We moved these properties to a separate *xarray* *Dataset* in *landlab* v2 grids and so were not being returned.

Uses the keywords *xy_of_lower_left* and *xy_of_center* when creating hex and radial grids, respectively—and *landlab* v2 change.